### PR TITLE
tea-ace-demo automated promote to qa

### DIFF
--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 images:
   - name: image-placeholder
     newName: tdolby/experimental
-    newTag: tea-github-action-crane-20241122004459-050e431
+    newTag: tea-github-action-crane-20241122004459-050e432
 components:
   - ../../variants/plaintext
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -5,10 +5,9 @@ resources:
 images:
   - name: image-placeholder
     newName: tdolby/experimental
-    #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e427
+    newTag: tea-github-action-crane-20241122004459-050e431
 components:
-  - ../../variants/secure
+  - ../../variants/plaintext
 patchesStrategicMerge:
   - deployment.yaml
   #- version.yaml

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -5,9 +5,10 @@ resources:
 images:
   - name: image-placeholder
     newName: tdolby/experimental
-    newTag: tea-github-action-crane-20241122004459-050e432
+    #newTag: tea-github-action-crane-20241122004459-050e41a
+    newTag: tea-github-action-crane-20241122004459-050e433
 components:
-  - ../../variants/plaintext
+  - ../../variants/secure
 patchesStrategicMerge:
   - deployment.yaml
   #- version.yaml


### PR DESCRIPTION
Updated on 20241125021459
########################################################################
Original source commits for tea-ace-demo:
90d49ed8ab9c6bce9fd512bf9e248f9ca1bc7c78: tdolby/experimental:tea-github-action-crane-20241122004459-050e433
########################################################################