### PR TITLE
tea-ace-demo automated promote to qa

### DIFF
--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e427
+    newTag: tea-github-action-crane-20241122004459-050e435
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e436
+    newTag: tea-github-action-crane-20241122004459-050e437
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e438
+    newTag: tea-github-action-crane-20241122004459-050e439
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e437
+    newTag: tea-github-action-crane-20241122004459-050e438
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e439
+    newTag: tea-github-action-crane-20241122004459-050e440
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e440
+    newTag: tea-github-action-crane-20241122004459-050e435
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e435
+    newTag: tea-github-action-crane-20241122004459-050e436
 components:
   - ../../variants/secure
 patchesStrategicMerge:


### PR DESCRIPTION
Updated on 20250218222422
***
Latest action run:
tea-ace-demo dev-to-qa manual promote (number 2)
https://github.com/trevor-dolby-at-ibm-com/ace-demo-gitops/actions/runs/13401168123
***