### PR TITLE
tea-ace-demo automated promote to qa

### DIFF
--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e441
+    newTag: tea-github-action-crane-20241122004459-050e442
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e427
+    newTag: tea-github-action-crane-20241122004459-050e440
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e441
+    newTag: tea-github-action-crane-20241122004459-050e440
 components:
   - ../../variants/secure
 patchesStrategicMerge:

--- a/tea-ace-demo/envs/qa/kustomization.yaml
+++ b/tea-ace-demo/envs/qa/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: image-placeholder
     newName: tdolby/experimental
     #newTag: tea-github-action-crane-20241122004459-050e41a
-    newTag: tea-github-action-crane-20241122004459-050e440
+    newTag: tea-github-action-crane-20241122004459-050e441
 components:
   - ../../variants/secure
 patchesStrategicMerge:


### PR DESCRIPTION
Updated on 20250218224402
***
Latest action run:
Create draft PR for dev-to-qa promotion of images (number 41)
https://github.com/trevor-dolby-at-ibm-com/ace-demo-gitops/actions/runs/13401443832
***
Original source commits for tea-ace-demo:
5f59ea30839ded921d5772cbe9f3d82bc5d26b92
***